### PR TITLE
Improve SMS implementation

### DIFF
--- a/src/UE/Application/Application.hpp
+++ b/src/UE/Application/Application.hpp
@@ -43,7 +43,7 @@ public:
     void handleViewSmsList() override;
     void handleViewSms(SmsRecord& sms) override;
     void handleSendSms(const common::PhoneNumber& from, const common::PhoneNumber& to, const std::string& text) override;
-    void handleSmsResponse(bool status);
+    void handleSmsResponse(bool status) override;
     void handleCallDrop(common::PhoneNumber from, common::PhoneNumber to) override;
     void handleCallAccept(common::PhoneNumber from, common::PhoneNumber to) override;
     void handleUnknownRecipient() override;

--- a/src/UE/Application/Ports/UserPort.cpp
+++ b/src/UE/Application/Ports/UserPort.cpp
@@ -81,10 +81,7 @@ void UserPort::showSmsList(SmsDB& smsdb)
     menu.clearSelectionList();
 
     for (SmsRecord& record : smsdb)
-    {
-        std::string itemText = "SMS From: " + std::to_string(record.m_from.value);
-        menu.addSelectionListItem(itemText, "");
-    }
+        menu.addSelectionListItem(record.getTitle(), "");
 
     gui.setAcceptCallback([this, &menu, &smsdb]() {
         auto selected = menu.getCurrentItemIndex();
@@ -95,6 +92,8 @@ void UserPort::showSmsList(SmsDB& smsdb)
         }
         unsigned int selectedIndex = selected.second;
         SmsRecord& selectedSms = *(smsdb.begin() + selectedIndex);
+        selectedSms.m_isNew = false;
+        gui.showNewSms(smsdb.hasUnreadMessages());
         handler->handleViewSms(selectedSms);
     });
 
@@ -108,7 +107,7 @@ void UserPort::showSms(SmsRecord& sms)
     IUeGui::IListViewMode& menu = gui.setListViewMode();
     menu.clearSelectionList();
 
-    if(sms.m_status == SmsStatus::FAILED)
+    if (sms.m_status == SmsStatus::FAILED)
     {
         menu.addSelectionListItem("Message failed\n to be delivered", "");
     }

--- a/src/UE/Application/SmsDB.cpp
+++ b/src/UE/Application/SmsDB.cpp
@@ -2,6 +2,21 @@
 
 namespace ue
 {
+std::string SmsRecord::getTitle() const
+{
+    std::string buffer;
+
+    if (m_isNew)
+        buffer += "(NEW) ";
+
+    if (m_direction == SmsDir::RECEIVED)
+        buffer += "from: " + std::to_string(m_from.value);
+    else if (m_direction == SmsDir::SENT)
+        buffer += "to: " + std::to_string(m_from.value);
+
+    return buffer;
+}
+
 void SmsDB::addReceivedSms(
 	common::PhoneNumber from,
 	common::PhoneNumber to,
@@ -13,6 +28,7 @@ void SmsDB::addReceivedSms(
 	sms.m_from = from;
 	sms.m_to = to;
 	sms.m_message = message;
+	sms.m_isNew = true;
 
 	m_database.push_back(std::move(sms));
 }
@@ -28,6 +44,7 @@ void SmsDB::addSms(
     sms.m_from = from;
     sms.m_to = to;
     sms.m_message = message;
+    sms.m_isNew = false;
 
     m_database.push_back(std::move(sms));
 }
@@ -42,6 +59,15 @@ void SmsDB::markLastSmsSentAsFailed()
             return;
         }
     }
+}
+
+bool SmsDB::hasUnreadMessages() const
+{
+    for (const SmsRecord& rec : m_database)
+        if (rec.m_isNew)
+            return true;
+
+    return false;
 }
 
 std::vector<SmsRecord>::iterator SmsDB::begin()

--- a/src/UE/Application/SmsDB.hpp
+++ b/src/UE/Application/SmsDB.hpp
@@ -30,6 +30,9 @@ struct SmsRecord
 	common::PhoneNumber m_to; // Phone number of receiver
 	std::string m_message; // Message of the SMS
 	SmsStatus m_status = SmsStatus::SUCCESS; // Status of the SMS
+	bool m_isNew = false; // If true, the message is unread.
+
+	std::string getTitle() const;
 };
 
 class SmsDB
@@ -48,6 +51,7 @@ public:
         const std::string& message);
 
 	void markLastSmsSentAsFailed();
+	bool hasUnreadMessages() const;
 
 	// SmsDB has begin() and end(), so it can be easily iterated over all the messages in the database.
 	std::vector<SmsRecord>::iterator begin();

--- a/src/UE/Application/States/SendingCallState.cpp
+++ b/src/UE/Application/States/SendingCallState.cpp
@@ -62,4 +62,17 @@ void SendingCallState::handleCallRequest(common::MessageId msgId,
     context.user.showIncomingCall(from, to);
 }
 
+void SendingCallState::handleIncomingSMS(common::MessageId msgId,
+                                       common::PhoneNumber from,
+                                       common::PhoneNumber to,
+                                       const std::string& text)
+{
+    std::string log = std::string("Received message from ")
+    + std::to_string(from.value) + std::string(", content: ") + text;
+
+    logger.logInfo(log);
+    context.smsdb.addReceivedSms(from, to, text); // Received SMS(from,text) stored in SMS DB (postcondition 1)
+    context.user.showNewMessageIndicator(); // User is informed new SMS arrived (postcondition 2)
+}
+
 }

--- a/src/UE/Application/States/SendingCallState.hpp
+++ b/src/UE/Application/States/SendingCallState.hpp
@@ -18,6 +18,10 @@ public:
                            common::PhoneNumber to,
                            const std::string &enc) override;
     void handleCallDrop(common::PhoneNumber from, common::PhoneNumber to) override;
+    void handleIncomingSMS(common::MessageId msgId,
+                           common::PhoneNumber from,
+                           common::PhoneNumber to,
+                           const std::string& text) override;
 
 private:
     common::PhoneNumber m_from;

--- a/src/UE/Application/States/TalkingState.cpp
+++ b/src/UE/Application/States/TalkingState.cpp
@@ -54,4 +54,17 @@ void TalkingState::handleCallRequest(common::MessageId msgId,
                                      common::PhoneNumber to,
                                      const std::string &enc)
 {}
+
+void TalkingState::handleIncomingSMS(common::MessageId msgId,
+                                       common::PhoneNumber from,
+                                       common::PhoneNumber to,
+                                       const std::string& text)
+{
+    std::string log = std::string("Received message from ")
+    + std::to_string(from.value) + std::string(", content: ") + text;
+
+    logger.logInfo(log);
+    context.smsdb.addReceivedSms(from, to, text); // Received SMS(from,text) stored in SMS DB (postcondition 1)
+    context.user.showNewMessageIndicator(); // User is informed new SMS arrived (postcondition 2)
+}
 }

--- a/src/UE/Application/States/TalkingState.hpp
+++ b/src/UE/Application/States/TalkingState.hpp
@@ -19,6 +19,10 @@ public:
                            common::PhoneNumber from,
                            common::PhoneNumber to,
                            const std::string &enc) override;
+    void handleIncomingSMS(common::MessageId msgId,
+                            common::PhoneNumber from,
+                            common::PhoneNumber to,
+                            const std::string& text) override;
 
 private:
     common::PhoneNumber m_from;


### PR DESCRIPTION
This PR:
* Implements SMS handling in sending call and talking states.
* Makes SMS indicator refresh after user reads the message.
* Names SMS acording to direction and if the message is unread, it will be marked as `(NEW)`.

Fix #28 
Fix #29